### PR TITLE
Improve the response handling for eval modal calls

### DIFF
--- a/reinhard/components/sudo.py
+++ b/reinhard/components/sudo.py
@@ -358,9 +358,7 @@ async def eval_command(
 
     assert first_response is not None
     message = await respond(
-        **first_response.to_kwargs() | {"attachments": attachments},
-        components=paginator.rows,
-        **kwargs,
+        **first_response.to_kwargs() | {"attachments": attachments}, components=paginator.rows, **kwargs
     )
     _try_deregister(component_client, message)
     component_client.register_executor(paginator, message=message)


### PR DESCRIPTION
This ensures that any calls to `ctx.respond` within the eval context won't update the original eval response message